### PR TITLE
Added forSavedEvents.

### DIFF
--- a/api/library/EventSource/Store.hs
+++ b/api/library/EventSource/Store.hs
@@ -131,11 +131,13 @@ foldSubAsync sub onEvent onError =
   async $ foldSub sub onEvent onError
 
 --------------------------------------------------------------------------------
+-- | Similar to 'foldSub' but provides access to the 'SavedEvent' instead of
+--   decoded event.
 foldSubSaved :: (MonadIO m)
-        => Subscription
-        -> (SavedEvent -> m ())
-        -> (SomeException -> m ())
-        -> m ()
+             => Subscription
+             -> (SavedEvent -> m ())
+             -> (SomeException -> m ())
+             -> m ()
 foldSubSaved sub onEvent onError = loop
   where
     loop = do
@@ -145,11 +147,11 @@ foldSubSaved sub onEvent onError = loop
         Right a -> onEvent a >> loop
 
 --------------------------------------------------------------------------------
-foldSubSavedAsync ::
-                Subscription
-             -> (SavedEvent -> IO ())
-             -> (SomeException -> IO ())
-             -> IO (Async ())
+-- | Asynchronous version of 'foldSubSaved'.
+foldSubSavedAsync :: Subscription
+                  -> (SavedEvent -> IO ())
+                  -> (SomeException -> IO ())
+                  -> IO (Async ())
 foldSubSavedAsync sub onEvent onError =
   async $ foldSubSaved sub onEvent onError
 
@@ -263,8 +265,8 @@ foldEvents store stream k seed =
   foldEventsM store stream (\s a -> return $ k s a) seed
 
 --------------------------------------------------------------------------------
--- | Like `forEvents` but provides access to SavedEvents instead of
---   decoded events.
+-- | Like `forEvents` but provides access to 'SavedEvent' instead of
+--   decoded event.
 forSavedEvents :: (MonadIO m, Store store)
                => store
                -> StreamName
@@ -283,11 +285,11 @@ forSavedEvents store name k = do
 --------------------------------------------------------------------------------
 -- | Like 'forSavedEvents' but expose signature similar to 'foldM'.
 foldSavedEventsM :: (MonadIO m, Store store)
-            => store
-            -> StreamName
-            -> (s -> SavedEvent -> m s)
-            -> s
-            -> ExceptT ForEventFailure m s
+                 => store
+                 -> StreamName
+                 -> (s -> SavedEvent -> m s)
+                 -> s
+                 -> ExceptT ForEventFailure m s
 foldSavedEventsM store stream k seed = mapExceptT trans action
   where
     trans m = evalStateT m seed
@@ -302,11 +304,11 @@ foldSavedEventsM store stream k seed = mapExceptT trans action
 --------------------------------------------------------------------------------
 -- | Like 'foldSavedEventsM' but expose signature similar to 'foldl'.
 foldSavedEvents :: (MonadIO m, Store store)
-           => store
-           -> StreamName
-           -> (s -> SavedEvent -> s)
-           -> s
-           -> ExceptT ForEventFailure m s
+                => store
+                -> StreamName
+                -> (s -> SavedEvent -> s)
+                -> s
+                -> ExceptT ForEventFailure m s
 foldSavedEvents store stream k seed =
   foldSavedEventsM store stream (\s a -> return $ k s a) seed
 

--- a/store-specs/library/Test/EventSource/Store/Specification.hs
+++ b/store-specs/library/Test/EventSource/Store/Specification.hs
@@ -148,16 +148,13 @@ specification store = do
         events = fmap TestEvent values
         seed   = Right (0, EventNumber 0)
         
-        testFold :: Either Text (Int, EventNumber) -> SavedEvent -> Either Text (Int, EventNumber)
         testFold (Left e) _           = Left e
         testFold (Right (a, n)) saved =
-          let
-            n' = eventNumber saved
-            ee = decodeEvent $ savedEvent saved
-          in
-            case ee of
-              Left t               -> Left t
-              Right (TestEvent a') -> Right (a + a', max n n')
+          let n' = eventNumber saved
+              ee = decodeEvent $ savedEvent saved in
+          case ee of
+            Left t               -> Left t
+            Right (TestEvent a') -> Right (a + a', max n n')
         
     name <- freshStreamName
     _ <- wait =<< appendEvents store name AnyVersion events

--- a/store-specs/library/Test/EventSource/Store/Specification.hs
+++ b/store-specs/library/Test/EventSource/Store/Specification.hs
@@ -127,6 +127,48 @@ specification store = do
 
     st `shouldBe` (10 :: Int)
 
+  specify "API - forSavedEvents" $ do
+    let events = fmap TestEvent [0..9]
+    name <- freshStreamName
+    _ <- wait =<< appendEvents store name AnyVersion events
+
+    let action = do
+          forSavedEvents store name $ \(_ :: SavedEvent) -> modify incr
+          get
+
+    res <- runExceptT $ mapExceptT (\m -> evalStateT m 0) action
+
+    res `shouldSatisfy` either (const False) (const True)
+    let Right st = res
+
+    st `shouldBe` (10 :: Int)
+
+  specify "API - foldSavedEvents" $ do
+    let values = [0..9]
+        events = fmap TestEvent values
+        seed   = Right (0, EventNumber 0)
+        
+        testFold :: Either Text (Int, EventNumber) -> SavedEvent -> Either Text (Int, EventNumber)
+        testFold (Left e) _           = Left e
+        testFold (Right (a, n)) saved =
+          let
+            n' = eventNumber saved
+            ee = decodeEvent $ savedEvent saved
+          in
+            case ee of
+              Left t               -> Left t
+              Right (TestEvent a') -> Right (a + a', max n n')
+        
+    name <- freshStreamName
+    _ <- wait =<< appendEvents store name AnyVersion events
+
+    res <- runExceptT $ foldSavedEvents store name testFold seed
+
+    res `shouldSatisfy` either (const False) (const True)
+    let Right st = res
+
+    st `shouldBe` Right (sum values, EventNumber 9)
+
   specify "API - Iterator.readAllEvents" $ do
     let events = fmap TestEvent [0..9]
     name <- freshStreamName


### PR DESCRIPTION
Hi @YoEight,

Sorry this took so long.  Needed to get my head around the State monad and a few other things.

Added forSavedEvents function.
Added related functions:
-   foldSavedEventsM
-   foldSavedEvents
-   foldSubSaved
-   foldSubSavedAsync

Added ForEventFailure to module exports so it can be used by clients of forSavedEvents.

Specs for forSavedEvents and foldSavedEvents added to Specfications.hs.

Tried to define forEvents using forSavedEvents using...

```
forEvents :: (MonadIO m, DecodeEvent a, Store store)
          => store
          -> StreamName
          -> (a -> m ())
forEvents store name k =
  forSavedEvents store name $ \s ->
    case decodeEvent $ savedEvent s of
      Left e  -> throwError $ ForEventDecodeFailure e
      Right a -> k a
```
but could not figure out compiler error...

```
Could not deduce (MonadError ForEventFailure m)
    arising from a use of 'throwError'
```
I'm not sure how to handle the error side of the decodeEvent.  The function passed to forSavedEvents need to return a `m ()` but not sure how to get the error into that type.

